### PR TITLE
Support for vuepress@next added

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,9 @@ if (!args.hostname) {
 const requires = esm(module)
 
 const tempData = resolve('node_modules/vuepress/lib/app/.temp/siteData')
+const nextTempData = resolve('node_modules/@vuepress/core/.temp/internal/siteData')
 
-const { siteData: { pages } } = requires(tempData)
+const { siteData: { pages } } = requires(existsSync(tempData) ? tempData : nextTempData)
 
 const urls = pages.map(i => {
   const lastmodISO = i.lastUpdated ? new Date(i.lastUpdated).toISOString() : undefined


### PR DESCRIPTION
I added support for vuepress@next, as a file location of generated "siteData" has changed from:

`node_modules/vuepress/lib/app/.temp/siteData`

to:

`node_modules/@vuepress/core/.temp/internal/siteData`

Problem described here:
https://github.com/ekoeryanto/vuepress-plugin-sitemap/issues/1