### PR TITLE
Readme update on module.exports sitemap configuration for VuePress 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ Sitemap generator plugin for vuepress.
 // .vuepress/config.js
 module.exports = {
   plugins: {
-    'sitemap': {
-      hostname: 'https://pake.web.id'
-    },
+    [
+      'sitemap',
+      {
+        hostname: 'https://pake.web.id',
+      },
+    ]    
   }
 }
 ```


### PR DESCRIPTION
Hi,

I'm finding a different way to configure the plugin. I think this is currently the supported method in VuePress 1.0.*

```Javascript
  plugins: [
    [
      'sitemap',
      {
        hostname: 'https://www.extly.com/docs',
      },
    ],
  ],
```
