### PR TITLE
Support frontmatter to exclude page from sitemap

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,12 @@ module.exports = (options, context) => {
       const pagesMap = new Map()
 
       pages.forEach(page => {
+        const metaRobots = (page.frontmatter.meta || []).find(meta => meta.name === "robots")
+        const excludePage = false === page.frontmatter.sitemap ||
+          (metaRobots ? (metaRobots.content || '').split(/,/).includes('noindex') : false)
+        if (excludePage) {
+          exclude.push(page.path)
+        }
         const lastmodISO = page.lastUpdated
           ? new Date(page.lastUpdated).toISOString()
           : undefined


### PR DESCRIPTION
This PR relates to #18. I've implemented support of parsing frontmatter data to exclude a page from sitemap. 

Like in the original feature request, you can set `sitemap: false`to exclude a specific page. It further checks for the meta data and searches for a `robots` value containing `noindex`.

Currently, if above data evaluates to true, the page path will be pushed to the exclude option parameter. It could be discussed, wether to break / return from the forEach loop instead.