### PR TITLE
fix date convert error

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = (options, context) => {
     exclude = [],
     dateFormatter = (lastUpdated) => {
       try {
-        new Date(lastUpdated).toISOString()
+        return new Date(lastUpdated).toISOString()
       } catch (ex) {
         // convert error,use today's date
         return new Date().toISOString();

--- a/index.js
+++ b/index.js
@@ -21,7 +21,14 @@ module.exports = (options, context) => {
     outFile = 'sitemap.xml',
     changefreq = 'daily',
     exclude = [],
-    dateFormatter = (lastUpdated) => new Date(lastUpdated).toISOString(),
+    dateFormatter = (lastUpdated) => {
+      try {
+        new Date(lastUpdated).toISOString()
+      } catch (ex) {
+        // convert error,use today's date
+        return new Date().toISOString();
+      }
+    },
     ...others
   } = options
 


### PR DESCRIPTION
On Windows: use the function `toLocaleString("zh-CN")` to output special symbols, resulting in date conversion failure.
for e.g.
```javascript
let nowDate = new Date().toLocaleString("zh-CN")
console.log(nowDate)
// output: 2020-7-23 7:16:11 ├F10: AM┤
// if convert to ISOString An exception will occur
console.log(new Date(nowDate).toISOString())
```
node version:v12.18.2
npm version:6.14.5

I tried to install the global internationalization support dependency,but it didn't work
> `npm install -g full-icu`