### PR TITLE
Fix npm, yarn commands to include -D

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Sitemap generator plugin for vuepress.
 * Yarn
 
   ```sh
-  yarn add vuepress-plugin-sitemap
+  yarn add -D vuepress-plugin-sitemap
   ```
 
 * NPM
 
   ```sh
-  npm install vuepress-plugin-sitemap
+  npm install -D vuepress-plugin-sitemap
   ```
 
 > in v2.0.0, dependencies except `sitemap` are moved to peerDependencies so we need to install `esm` module manually (`chalk` and `commander` are already installed by `vuepress`) when we use this plugin with *cli method*.


### PR DESCRIPTION
This PR fixes the installation commands to use `-D` flag which otherwise arouse #37 issue