### PR TITLE
Ability to set page priority for individual pages via front matter

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = (options, context) => {
     xmlNs,
     outFile = 'sitemap.xml',
     changefreq = 'daily',
+    priority = undefined,
     exclude = [],
     dateFormatter = (lastUpdated) => new Date(lastUpdated).toISOString(),
     ...others
@@ -86,6 +87,7 @@ module.exports = (options, context) => {
           page.path,
           {
             changefreq: fmOpts.changefreq || changefreq,
+            priority: fmOpts.priority || priority,
             lastmodISO,
             links,
             ...others


### PR DESCRIPTION
This PR enables [page priority](https://www.sitemaps.org/protocol.html#prioritydef) to be specified on a per-page basis via front matter like this:

```
---
sitemap:
  priority: 0.8
---
```

Example usage: https://github.com/typesense/typesense-website/commit/9edfa3c38c44c1105b438f9e2c77aff6e4bf972a#diff-fc07bc2b3fddf5766c06ca5dc2d4e755e956941ef1bca1a34e5e5f0f73979d66R1-R5