### PR TITLE
feat: exclude 404.html page by default #35

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,9 @@ module.exports = (options, context) => {
 
   return {
     generated () {
+      // to exclude 404 page explicitly by default
+      exclude.push('/404.html')
+
       if (!hostname) {
         return log(
           'Not generating sitemap because required "hostname" option doesn\'t exist',


### PR DESCRIPTION
Signed-off-by: Ayush P Gupta <ayushpguptaapg@gmail.com>

Fixes #35

Ignores 404 by default to prevent SEO crawlers to crawl this page